### PR TITLE
[CI TEST] Validate maintenance tests run when common changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,9 +45,25 @@ jobs:
               - '!**/*.svg'
             spark_connector_changes:
               - spark-connector/**
+            maintenance_changes:
+              - maintenance/**
+              - api/**
+              - common/**
+              - core/**
+              - catalogs/catalog-common/**
+              - clients/client-java/**
+              - integration-test-common/**
+              - server/**
+              - server-common/**
+              - build.gradle.kts
+              - settings.gradle.kts
+              - gradle.properties
+              - gradlew
+              - gradle/**
     outputs:
       source_changes: ${{ steps.filter.outputs.source_changes }}
       spark_connector_changes: ${{ steps.filter.outputs.spark_connector_changes }}
+      maintenance_changes: ${{ steps.filter.outputs.maintenance_changes }}
 
   compile-check:
     runs-on: ubuntu-latest
@@ -133,8 +149,28 @@ jobs:
           sudo dpkg -i libssl1.1_1.1.1f-1ubuntu2_amd64.deb  
 
       - name: Build with Gradle
-        run: ./gradlew build -PskipITs -PskipDockerTests=false -x :clients:client-python:build
+        run: |
+          gradle_args=(
+            build
+            -PskipITs
+            -PskipDockerTests=false
+            -x :clients:client-python:build
+          )
 
+          if [ "${{ needs.changes.outputs.maintenance_changes }}" != "true" ]; then
+            gradle_args+=(
+              -x :maintenance:optimizer-api:test
+              -x :maintenance:gravitino-updaters:test
+              -x :maintenance:optimizer:test
+              -x :maintenance:jobs:test
+            )
+          fi
+
+          printf './gradlew'
+          printf ' %q' "${gradle_args[@]}"
+          printf '\n'
+
+          ./gradlew "${gradle_args[@]}"
       - name: Release with Gradle
         run: ./gradlew clean && ./gradlew release -x test --rerun-tasks
 

--- a/common/src/test/resources/ci-maintenance-trigger.txt
+++ b/common/src/test/resources/ci-maintenance-trigger.txt
@@ -1,0 +1,1 @@
+Temporary file for validating maintenance build CI path filtering.


### PR DESCRIPTION
### What changes were proposed in this pull request?

Validate the build workflow change that keeps maintenance tests enabled when a dependency module such as `common` changes.

### Why are the changes needed?

To verify the new CI path filtering behavior on GitHub Actions before using the workflow change in a real PR.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

GitHub Actions validation in draft PR.
