### PR TITLE
[MINOR] test: Validate maintenance build include for common changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,10 +64,26 @@ jobs:
               - spark-connector/**
             mcp_server_changes:
               - mcp-server/**
+            maintenance_changes:
+              - maintenance/**
+              - api/**
+              - common/**
+              - core/**
+              - catalogs/catalog-common/**
+              - clients/client-java/**
+              - integration-test-common/**
+              - server/**
+              - server-common/**
+              - build.gradle.kts
+              - settings.gradle.kts
+              - gradle.properties
+              - gradlew
+              - gradle/**
     outputs:
       source_changes: ${{ steps.filter.outputs.source_changes }}
       spark_connector_changes: ${{ steps.filter.outputs.spark_connector_changes }}
       mcp_server_changes: ${{ steps.filter.outputs.mcp_server_changes }}
+      maintenance_changes: ${{ steps.filter.outputs.maintenance_changes }}
 
   compile-check:
     runs-on: ubuntu-latest
@@ -153,12 +169,37 @@ jobs:
           sudo dpkg -i libssl1.1_1.1.1f-1ubuntu2_amd64.deb  
 
       - name: Build with Gradle
-        if: needs.changes.outputs.mcp_server_changes == 'true'
-        run: ./gradlew build -PskipITs -PskipDockerTests=false -x :clients:client-python:build
+        run: |
+          gradle_args=(
+            build
+            -PskipITs
+            -PskipDockerTests=false
+            -x :clients:client-python:build
+          )
 
-      - name: Build with Gradle (skip mcp-server tests)
-        if: needs.changes.outputs.mcp_server_changes != 'true'
-        run: ./gradlew build -PskipITs -PskipDockerTests=false -x :clients:client-python:build -x :mcp-server:build -x :mcp-server:test -x :mcp-server:pylint -x :web-v2:web:build
+          if [ "${{ needs.changes.outputs.mcp_server_changes }}" != "true" ]; then
+            gradle_args+=(
+              -x :mcp-server:build
+              -x :mcp-server:test
+              -x :mcp-server:pylint
+              -x :web-v2:web:build
+            )
+          fi
+
+          if [ "${{ needs.changes.outputs.maintenance_changes }}" != "true" ]; then
+            gradle_args+=(
+              -x :maintenance:optimizer-api:test
+              -x :maintenance:gravitino-updaters:test
+              -x :maintenance:optimizer:test
+              -x :maintenance:jobs:test
+            )
+          fi
+
+          printf './gradlew'
+          printf ' %q' "${gradle_args[@]}"
+          printf '\n'
+
+          ./gradlew "${gradle_args[@]}"
 
       - name: Fetch base branch for coverage diff
         if: github.event_name == 'pull_request'

--- a/common/src/test/resources/ci-maintenance-common-trigger-20260312.properties
+++ b/common/src/test/resources/ci-maintenance-common-trigger-20260312.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+ci.maintenance.validation.case=common-upstream


### PR DESCRIPTION
### What changes were proposed in this pull request?

This validation PR applies the maintenance build CI change and adds a common-module trigger file to verify that maintenance tests still run when an upstream dependency module changes.

### Why are the changes needed?

This is a temporary CI validation PR to confirm that the new skip logic still includes maintenance tests for upstream dependency changes.

Fix: #(none, validation only)

### Does this PR introduce _any_ user-facing change?

No. This PR is only for CI validation.

### How was this patch tested?

Locally validated with Gradle dry-run. GitHub Actions on this draft PR is used to verify that the generated build command does not include maintenance test exclusions.
